### PR TITLE
Use kickass.cd instead of kat.ph

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ search('foobar').then(function(results) {
 		name: String, // Name of torrent,
 		category: String, // Category it's in
 		size: String, // Size of file
-		files: Number, // Number of files
 		age: String, // Age of result
 		seeds: Number, // Number of seeds
 		leech: Number, // Number of leeches

--- a/search.js
+++ b/search.js
@@ -7,7 +7,7 @@ var bluebird = require('bluebird'),
 module.exports = function search(query) {
   return request
     .getAsync({
-      url: 'http://kat.cr/usearch/' + encodeURIComponent(query) + '/',
+      url: 'http://kickass.cd/usearch/' + encodeURIComponent(query) + '/',
       gzip: true
     })
     .catch(function(e) {
@@ -28,10 +28,9 @@ module.exports = function search(query) {
             name: $(this).find('.cellMainLink').text(),
             category: $(this).find('.cellMainLink').next().text().trim().replace(/^in\s+/, '').split(' > '),
             size: $($(this).children()[1]).text(),
-            files: +$($(this).children()[2]).text(),
-            age: $($(this).children()[3]).text(),
-            seeds: +$($(this).children()[4]).text(),
-            leech: +$($(this).children()[5]).text(),
+            age: $($(this).children()[2]).text(),
+            seeds: +$($(this).children()[3]).text(),
+            leech: +$($(this).children()[4]).text(),
             magnet: $(this).find('a[title="Torrent magnet link"]').attr('href'),
             torrent: $(this).find('a[title="Download torrent file"]').attr('href')
           };

--- a/spec/search-spec.js
+++ b/spec/search-spec.js
@@ -8,7 +8,6 @@ describe('Parse kat.ph results', function() {
       expect(results.length).toBeGreaterThan(0);
       expect(results[0].name.length).toBeGreaterThan(0);
       expect(results[0].size.length).toBeGreaterThan(0);
-      expect(results[0].files).toBeGreaterThan(0);
       expect(results[0].age.length).toBeGreaterThan(0);
       expect(results[0].seeds).toBeGreaterThan(-1);
       expect(results[0].leech).toBeGreaterThan(-1);


### PR DESCRIPTION
https://kat.ph is dead. Updated this module to use https://kickass.cd (which doesn't show the files in the search request).